### PR TITLE
FIX "Strict standards: Non-static method" 

### DIFF
--- a/lib/DigitalPianism/TestFramework/Helper/Magento.php
+++ b/lib/DigitalPianism/TestFramework/Helper/Magento.php
@@ -2,7 +2,7 @@
 
 class DigitalPianism_TestFramework_Helper_Magento
 {
-    private function patchMagentoAutoloader()
+    private static function patchMagentoAutoloader()
     {
         $mageErrorHandler = set_error_handler(function () {
             return false;


### PR DESCRIPTION
FIX "Strict standards: Non-static method" on patchMagentoAutoloader() function call