### PR TITLE
Use copy instead links in modman file

### DIFF
--- a/modman
+++ b/modman
@@ -1,2 +1,6 @@
 # DigitalPianism_TestFramework
-lib/DigitalPianism/TestFramework    lib/DigitalPianism/TestFramework
+
+# remove folder if exists
+@shell if [ -d $PROJECT/lib/DigitalPianism/TestFramework ]; then rm -rf $PROJECT/lib/DigitalPianism/TestFramework; fi
+# COPY instead of link as links will not work if used with modman
+@shell cp -rf $MODULE/lib/DigitalPianism/TestFramework $PROJECT/lib/DigitalPianism/TestFramework


### PR DESCRIPTION
Relative imports used by lib code (`lib/DigitalPianism/TestFramework/Helper/Magento.php` for example) will not work when using modman as links are used so the base dir is under `.modman` folder hierarchy.

Changed to use `@shell` modman commands to first delete old folder if exists and then *copy* `lib/*` instead linking it.